### PR TITLE
Nil attribute values throw an error

### DIFF
--- a/lib/omniauth/strategies/wsfed/saml_1_token.rb
+++ b/lib/omniauth/strategies/wsfed/saml_1_token.rb
@@ -31,7 +31,7 @@ module OmniAuth
                 value = []
                 attr_element.elements.each { |element| value << element.text }
               else
-                value = attr_element.elements.first.text.lstrip.rstrip
+                value = attr_element.elements.first.text.to_s.lstrip.rstrip
               end
 
               result[name] = value

--- a/lib/omniauth/strategies/wsfed/saml_2_token.rb
+++ b/lib/omniauth/strategies/wsfed/saml_2_token.rb
@@ -31,7 +31,7 @@ module OmniAuth
                 value = []
                 attr_element.elements.each { |element| value << element.text }
               else
-                value = attr_element.elements.first.text.lstrip.rstrip
+                value = attr_element.elements.first.text.to_s.lstrip.rstrip
               end
 
               result[name] = value


### PR DESCRIPTION
When testing responses for a user with no permissions, omniauth throws an error because `attr_element.elements.first.text` is nil. Added a `#to_s` to convert any nil values to an empty string. 
